### PR TITLE
Keys creation fix

### DIFF
--- a/release-tools/Makefile
+++ b/release-tools/Makefile
@@ -139,7 +139,7 @@ minio-uninstall:
 	kubectl delete -f ./examples/example-minio-data.yaml
 
 keys-installation:
-	@ ./release-tools/generate-keys.sh $(KEY_DIR) ;\
+	@ ./release-tools/generate-keys.sh $(KEY_DIR) $(DATASET_OPERATOR_NAMESPACE);\
 	export CA_PEM_B64="$$(openssl base64 -A < "$(KEY_DIR)/ca.crt")" ;\
 	$(SHELL_EXPORT) kubectl -n $(DATASET_OPERATOR_NAMESPACE) create secret tls webhook-server-tls \
             --cert "$(KEY_DIR)/webhook-server-tls.crt" \

--- a/release-tools/generate-keys.sh
+++ b/release-tools/generate-keys.sh
@@ -25,6 +25,7 @@
 : ${1?'missing key directory'}
 
 key_dir="$1"
+namespace=$2
 
 chmod 0700 "$key_dir"
 cd "$key_dir"
@@ -34,5 +35,5 @@ openssl req -nodes -new -x509 -keyout ca.key -out ca.crt -subj "/CN=Admission Co
 # Generate the private key for the webhook server
 openssl genrsa -out webhook-server-tls.key 2048
 # Generate a Certificate Signing Request (CSR) for the private key, and sign it with the private key of the CA.
-openssl req -new -key webhook-server-tls.key -subj "/CN=webhook-server.default.svc" \
+openssl req -new -key webhook-server-tls.key -subj "/CN=webhook-server.${namespace}.svc" \
     | openssl x509 -req -CA ca.crt -CAkey ca.key -CAcreateserial -out webhook-server-tls.crt

--- a/src/dataset-operator/deploy/webhook.yaml.template
+++ b/src/dataset-operator/deploy/webhook.yaml.template
@@ -1,9 +1,9 @@
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration
 metadata:
-  name: mutating-webhook
+  name: dlf-mutating-webhook-cfg
 webhooks:
-  - name: foo.bar.svc
+  - name: admission.webhook.dlf
     clientConfig:
       service:
         name: webhook-server


### PR DESCRIPTION
Certificates for the webhook were generated with a fixed namespace name. This is now decided at installation time.

Fixed also the name of the webhook to something more related to this project.