### PR TITLE
Minikube driver none

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,22 @@
-DOCKER_REGISTRY_COMPONENTS := the_registry_to_use_for_components
-DOCKER_REGISTRY_SECRET := your_already_installed_secrets
+DOCKER_REGISTRY_COMPONENTS ?= the_registry_to_use_for_components
+DOCKER_REGISTRY_SECRET ?= your_already_installed_secrets
 # you need something like this:
 # kubectl create secret generic regcred -n NAMESPACE_OF_OPERATOR --from-file=.dockerconfigjson=$(echo $HOME)/.docker/config.json --type=kubernetes.io/dockerconfigjson
-PULL_COMPONENTS := false
+PULL_COMPONENTS ?= false
 
-DOCKER_REGISTRY_SIDECARS := quay.io/k8scsi
+DOCKER_REGISTRY_SIDECARS ?= quay.io/k8scsi
 # if you pull from public use quay.io/k8scsi
-PULL_SIDECARS := false
+PULL_SIDECARS ?= false
 
-DATASET_OPERATOR_NAMESPACE := default
-NAMESPACES_TO_MONITOR := default
+DATASET_OPERATOR_NAMESPACE ?= default
+NAMESPACES_TO_MONITOR ?= default
 
 # if you are building use master, if you are pulling use canary
-EXTERNAL_ATTACHER_TAG := v2.1.1
+EXTERNAL_ATTACHER_TAG ?= v2.1.1
 #working in ppc64le v2.1.1
-EXTERNAL_PROVISIONER_TAG := v1.5.0
+EXTERNAL_PROVISIONER_TAG ?= v1.5.0
 #working in ppc64le v1.5.0
-NODE_DRIVER_REGISTRAR_TAG := master
+NODE_DRIVER_REGISTRAR_TAG ?= master
 #working in ppc64le master
 
 minikube-uninstall: noobaa-uninstall undeployment

--- a/examples/noobaa/noobaa_install.sh
+++ b/examples/noobaa/noobaa_install.sh
@@ -31,9 +31,14 @@ function install_noobaa() {
 
 function build_data_loader() {
 	echo -n "Building NooBaa data loader..."
-	eval $(minikube docker-env)
+	driver_check=$(cat $HOME/.minikube/machines/minikube/config.json  | grep DriverName)
+    if [[ $driver_check == *"virtualbox"* ]]; then
+      eval $(minikube docker-env)
+    fi
 	docker build -f ${DIR}/Dockerfile-awscli-alpine -t awscli-alpine . > /dev/null 2>&1
-	eval $(minikube docker-env -u)
+	if [[ $driver_check == *"virtualbox"* ]]; then
+      eval $(minikube docker-env -u)
+    fi
 	echo "done"
 }
 

--- a/examples/noobaa/noobaa_install.sh
+++ b/examples/noobaa/noobaa_install.sh
@@ -32,11 +32,11 @@ function install_noobaa() {
 function build_data_loader() {
 	echo -n "Building NooBaa data loader..."
 	driver_check=$(cat $HOME/.minikube/machines/minikube/config.json  | grep DriverName)
-    if [[ $driver_check == *"virtualbox"* ]]; then
+    if [[ $driver_check != *"none"* ]]; then
       eval $(minikube docker-env)
     fi
 	docker build -f ${DIR}/Dockerfile-awscli-alpine -t awscli-alpine . > /dev/null 2>&1
-	if [[ $driver_check == *"virtualbox"* ]]; then
+	if [[ $driver_check != *"none"* ]]; then
       eval $(minikube docker-env -u)
     fi
 	echo "done"

--- a/release-tools/Makefile
+++ b/release-tools/Makefile
@@ -83,9 +83,11 @@ endef
 #1: user friendly name
 #2: image to load
 define load_containers_minikube
-    @if [[ $$driver_check == *"virtualbox"* ]]; then docker save $(2) | gzip > ./release-tools/_tmp/$(1).tar.gz;\
-    eval $$(minikube docker-env -u);\
+    @driver_check=$$(cat $$HOME/.minikube/machines/minikube/config.json  | grep DriverName);\
+    if [[ $$driver_check != *"none"* ]]; then docker save $(2) | gzip > ./release-tools/_tmp/$(1).tar.gz;\
+    eval $$(minikube docker-env);\
     docker load < ./release-tools/_tmp/$(1).tar.gz;\
+    eval $$(minikube docker-env -u);\
     rm -rf ./release-tools/_tmp/$(1).tar.gz;\
     fi;
 endef

--- a/release-tools/Makefile
+++ b/release-tools/Makefile
@@ -84,7 +84,7 @@ endef
 #2: image to load
 define load_containers_minikube
     @docker save $(2) | gzip > ./release-tools/_tmp/$(1).tar.gz;\
-    eval $$(minikube docker-env) ;\
+    if [[ $$driver_check == *"virtualbox"* ]]; then eval $$(minikube docker-env -u); fi;\
     docker load < ./release-tools/_tmp/$(1).tar.gz ;\
     rm -rf ./release-tools/_tmp/$(1).tar.gz
 endef

--- a/release-tools/Makefile
+++ b/release-tools/Makefile
@@ -83,10 +83,11 @@ endef
 #1: user friendly name
 #2: image to load
 define load_containers_minikube
-    @docker save $(2) | gzip > ./release-tools/_tmp/$(1).tar.gz;\
-    if [[ $$driver_check == *"virtualbox"* ]]; then eval $$(minikube docker-env -u); fi;\
+    @if [[ $$driver_check == *"virtualbox"* ]]; then docker save $(2) | gzip > ./release-tools/_tmp/$(1).tar.gz;\
+    eval $$(minikube docker-env -u);\
     docker load < ./release-tools/_tmp/$(1).tar.gz ;\
-    rm -rf ./release-tools/_tmp/$(1).tar.gz
+    rm -rf ./release-tools/_tmp/$(1).tar.gz;\
+    fi;\
 endef
 
 build-containers:

--- a/release-tools/Makefile
+++ b/release-tools/Makefile
@@ -85,9 +85,9 @@ endef
 define load_containers_minikube
     @if [[ $$driver_check == *"virtualbox"* ]]; then docker save $(2) | gzip > ./release-tools/_tmp/$(1).tar.gz;\
     eval $$(minikube docker-env -u);\
-    docker load < ./release-tools/_tmp/$(1).tar.gz ;\
+    docker load < ./release-tools/_tmp/$(1).tar.gz;\
     rm -rf ./release-tools/_tmp/$(1).tar.gz;\
-    fi;\
+    fi;
 endef
 
 build-containers:


### PR DESCRIPTION
This PR only modifies the makefiles so that we are able to build, deploy the framework in the case where minikube uses driver none.
This is done primarily for travis integration tests