### PR TITLE
Introduce cache.hostname label in dataset

### DIFF
--- a/plugins/ceph-cache-plugin/deploy/operator.yaml
+++ b/plugins/ceph-cache-plugin/deploy/operator.yaml
@@ -37,7 +37,5 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-            # - name: ROOK_RGW_NODE
-            #   value: "hostname that rgw should be scheduled"
       imagePullSecrets:
         - name: ${DOCKER_REGISTRY_SECRET}

--- a/plugins/ceph-cache-plugin/deploy/operator.yaml
+++ b/plugins/ceph-cache-plugin/deploy/operator.yaml
@@ -37,5 +37,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            # - name: ROOK_RGW_NODE
+            #   value: "hostname that rgw should be scheduled"
       imagePullSecrets:
         - name: ${DOCKER_REGISTRY_SECRET}

--- a/plugins/ceph-cache-plugin/deploy/role.yaml
+++ b/plugins/ceph-cache-plugin/deploy/role.yaml
@@ -6,6 +6,7 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - nodes
   - pods
   - services
   - services/finalizers

--- a/plugins/ceph-cache-plugin/pkg/controller/dataset/ceph_related_objects.go
+++ b/plugins/ceph-cache-plugin/pkg/controller/dataset/ceph_related_objects.go
@@ -70,8 +70,8 @@ func createCephObjectStore(c client.Client,dataset *comv1alpha1.Dataset) error{
 		},
 	}
 
-	rgwNode, present := os.LookupEnv("ROOK_RGW_NODE")
-	if present {
+	rgwNode, found := dataset.Labels["cache.hostname"]
+	if found {
 		var nodes = &corev1.NodeList{}
 		err := populateListOfObjects(c, nodes, []client.ListOption{
 			client.MatchingLabels{"kubernetes.io/hostname": rgwNode},


### PR DESCRIPTION
This patch supports setting the NodeAffinity of the rgw pod (in general, can be used by any future caching mechanisms), spawned on-the-fly by DLF, to the node with a hostname that matches the label `cache.hostname`. Furthermore, to accommodate any changes to the nodes of the k8s cluster that may result in a pending rgw if a node with the specified hostname does not exist, this patchset firstly checks if the respective node exists and only then assigns the NodeAffinity of the rgw pod.