### PR TITLE
[ppc64le] goofys fixes

### DIFF
--- a/src/csi-s3/cmd/s3driver/Dockerfile.full
+++ b/src/csi-s3/cmd/s3driver/Dockerfile.full
@@ -36,10 +36,11 @@ RUN cd /opt && \
     cp /go.mod.goofys go.mod && \
     git submodule init && \
     git submodule update && \
+    go get ./... && \
     if [ "$ARCH" = "ppc64le" ]; then \
-    sed -i 's/4096/65536/g' /opt/goofys/vendor/github.com/jacobsa/fuse*/internal/buffer/in_message.go ; \
-    sed -i 's/17/21/g' /opt/goofys/vendor/github.com/jacobsa/fuse*/internal/buffer/in_message_linux.go ; \
-    sed -i 's/17/21/g' /opt/goofys/vendor/github.com/jacobsa/fuse*/internal/buffer/out_message_linux.go ; \
+	  sed -i 's/4096/65536/g' /go/pkg/mod/github.com/kahing/fuse*/internal/buffer/in_message.go ; \
+	  sed -i 's/17/21/g' /go/pkg/mod/github.com/kahing/fuse*/internal/buffer/in_message_linux.go ; \
+	  sed -i 's/17/21/g' /go/pkg/mod/github.com/kahing/fuse*/internal/buffer/out_message_linux.go ; \
     else echo 'true'; fi && \
     go build
 


### PR DESCRIPTION
As pointed by [this issue](https://github.com/kahing/goofys/issues/357) vanilla goofys sources exhibit the following issue when run on ppc64le architecture
```
panic: Page size is unexpectedly 65536

goroutine 1 [running]:
github.com/jacobsa/fuse/internal/buffer.init.0()
	/go/pkg/mod/github.com/kahing/fusego@v0.0.0-20200327063725-ca77844c7bcc/internal/buffer/in_message.go:33 +0xbc
```

After some commits on the goofys master this issue resurfaced for ppc64le. This PR is applying the latest fixes to fix this behavior of goofys on ppc64le