### PR TITLE
remove namespace from helm chart

### DIFF
--- a/chart/templates/namespace.yaml
+++ b/chart/templates/namespace.yaml
@@ -1,6 +1,0 @@
-kind: Namespace
-apiVersion: v1
-metadata:
-  name: dlf
-  labels:
-  {{- include "common.labels" . | nindent 4 }}


### PR DESCRIPTION
To install helm chart with helm3, it fails with following error
```
Error: rendered manifests contain a resource that already exists. Unable to continue with install: Namespace "dlf" in namespace "" exists and cannot be imported into the current release: invalid ownership metadata; annotation validation error: missing key "meta.helm.sh/release-name": must be set to "dataset-lifecycle-framework"; annotation validation error: missing key "meta.helm.sh/release-namespace": must be set to "dlf"
```

To install with creating namespace with helm3, you can run `helm install --create-namespace`