### PR TITLE
Implement Provision field in DatasetSpec

### DIFF
--- a/examples/templates/example-dataset-s3-provision.yaml
+++ b/examples/templates/example-dataset-s3-provision.yaml
@@ -1,0 +1,14 @@
+apiVersion: com.ie.ibm.hpsys/v1alpha1
+kind: Dataset
+metadata:
+  name: example-dataset
+spec:
+  local:
+    type: "COS"
+    secret-name: "{SECRET_NAME}" #see s3-secrets.yaml for an example
+    secret-namespace: "{SECRET_NAMESPACE}" #optional if the secret is in the same ns as dataset
+    endpoint: "{S3_SERVICE_URL}"
+    bucket: "{BUCKET_NAME}"
+    readonly: "true" # default is false
+    provision: "true" # DLF will allocate bucket on the COS if it doesn't exist [Default: false]
+    region: "" #it can be empty

--- a/plugins/ceph-cache-plugin/pkg/controller/dataset/dataset_controller.go
+++ b/plugins/ceph-cache-plugin/pkg/controller/dataset/dataset_controller.go
@@ -294,10 +294,11 @@ func (r *ReconcileDataset) Reconcile(request reconcile.Request) (reconcile.Resul
 		Spec: comv1alpha1.DatasetSpec{
 			Local: map[string]string{
 				"type": "COS",
-				"accessKeyID":    string(AccessKey),
+				"accessKeyID":     string(AccessKey),
 				"secretAccessKey": string(SecretKey),
 				"endpoint":        "http://"+InternalEndpoint,
 				"bucket":          datasetInstance.Spec.Local["bucket"],
+				"provision": 	   "true", //TODO fix this in S3Mirror radosgw
 			},
 		},
 	}

--- a/src/csi-s3/pkg/s3/config.go
+++ b/src/csi-s3/pkg/s3/config.go
@@ -9,4 +9,5 @@ type Config struct {
 	Mounter         string
 	ExistingBucket  string
 	Readonly		bool
+	Provision       bool
 }

--- a/src/csi-s3/pkg/s3/controllerserver.go
+++ b/src/csi-s3/pkg/s3/controllerserver.go
@@ -78,8 +78,12 @@ func (cs *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 		return nil, fmt.Errorf("failed to check if bucket %s exists: %v", bucketName, err)
 	}
 	if exists == false {
-		if err = s3.createBucket(bucketName); err != nil {
-			return nil, fmt.Errorf("failed to create volume %s: %v", volumeID, err)
+		if s3.cfg.Provision {
+			if err = s3.createBucket(bucketName); err != nil {
+				return nil, fmt.Errorf("failed to create volume %s: %v", volumeID, err)
+			}
+		} else {
+			return nil, fmt.Errorf("s3 bucket: %s does not exist", bucketName)
 		}
 	}
 	//b := &bucket{

--- a/src/csi-s3/pkg/s3/s3-client.go
+++ b/src/csi-s3/pkg/s3/s3-client.go
@@ -47,6 +47,8 @@ func newS3Client(cfg *Config) (*s3Client, error) {
 func newS3ClientFromSecrets(secrets map[string]string) (*s3Client, error) {
 	readonly := false
 	readonly, _ = strconv.ParseBool(secrets["readonly"])
+	provision := false
+	provision, _ = strconv.ParseBool(secrets["provision"])
 	return newS3Client(&Config{
 		AccessKeyID:     secrets["accessKeyID"],
 		SecretAccessKey: secrets["secretAccessKey"],
@@ -54,6 +56,7 @@ func newS3ClientFromSecrets(secrets map[string]string) (*s3Client, error) {
 		Endpoint:        secrets["endpoint"],
 		ExistingBucket:  secrets["bucket"],
 		Readonly:		 readonly,
+		Provision:       provision,
 		// Mounter is set in the volume preferences, not secrets
 		Mounter: "",
 	})

--- a/src/dataset-operator/pkg/controller/datasetinternal/datasetinternal_controller.go
+++ b/src/dataset-operator/pkg/controller/datasetinternal/datasetinternal_controller.go
@@ -171,8 +171,18 @@ func processLocalDatasetCOS(cr *comv1alpha1.DatasetInternal, rc *ReconcileDatase
 	if readonlyValueString, ok := cr.Spec.Local["readonly"]; ok {
 		readonly = readonlyValueString
 	}
+
+	provision := "false"
+
+	if provisionValueString, ok := cr.Spec.Local["provision"]; ok {
+		provisionBool, err := strconv.ParseBool(provisionValueString)
+		if err == nil {
+			provision = strconv.FormatBool(provisionBool)
+		}
+	}
+
 	extract := "false"
-	if(len(cr.Spec.Extract)>0) {
+	if len(cr.Spec.Extract) > 0 {
 		extract = cr.Spec.Extract
 	}
 
@@ -184,6 +194,7 @@ func processLocalDatasetCOS(cr *comv1alpha1.DatasetInternal, rc *ReconcileDatase
 		"region":          region,
 		"readonly":        readonly,
 		"extract":         extract,
+		"provision":       provision,
 	}
 
 	labels := map[string]string{


### PR DESCRIPTION
This PR introduces ```provision``` flag in the Dataset Spec. At the moment DLF, in the case of a COS type dataset, creates the bucket automatically if it does not exist on the remote COS. With the provision flag (default value is false) in this PR, the aforementioned behaviour changes and only when the user explicitly specifies ```provision: true```, inside the spec of the Dataset, DLF will create the bucket if it does not exist on the remote COS. 
