### PR TITLE
Initial support for secrets for object storage datasets

### DIFF
--- a/examples/templates/example-dataset-s3-secrets.yaml
+++ b/examples/templates/example-dataset-s3-secrets.yaml
@@ -1,0 +1,13 @@
+apiVersion: com.ie.ibm.hpsys/v1alpha1
+kind: Dataset
+metadata:
+  name: example-dataset
+spec:
+  local:
+    type: "COS"
+    secret-name: "{SECRET_NAME}" #see s3-secrets.yaml for an example
+    secret-namespace: "{SECRET_NAMESPACE}" #optional if the secret is in the same ns as dataset
+    endpoint: "{S3_SERVICE_URL}"
+    bucket: "{BUCKET_NAME}"
+    readonly: "true" # default is false
+    region: "" #it can be empty

--- a/examples/templates/example-s3-secret.yaml
+++ b/examples/templates/example-s3-secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: s3secret
+stringData:
+  accessKeyID: "{AWS_ACCESS_KEY}"
+  secretAccessKey: "{AWS_SECRET_ACCESS_KEY}"

--- a/src/dataset-operator/pkg/controller/datasetinternal/datasetinternal_controller.go
+++ b/src/dataset-operator/pkg/controller/datasetinternal/datasetinternal_controller.go
@@ -196,7 +196,7 @@ func processLocalDatasetCOS(cr *comv1alpha1.DatasetInternal, rc *ReconcileDatase
 	}
 
 	if !authProvided {
-		err := errors.New("No useable secret provided for authentication")
+		err := errors.NewBadRequest("No useable secret provided for authentication")
 		processLocalDatasetLogger.Error(err, "Failed to initialise", "Dataset.Name", cr.Name)
 		return reconcile.Result{}, err
 	}

--- a/src/dataset-operator/pkg/controller/datasetinternal/datasetinternal_controller.go
+++ b/src/dataset-operator/pkg/controller/datasetinternal/datasetinternal_controller.go
@@ -162,17 +162,56 @@ func (r *ReconcileDatasetInternal) Reconcile(request reconcile.Request) (reconci
 func processLocalDatasetCOS(cr *comv1alpha1.DatasetInternal, rc *ReconcileDatasetInternal) (reconcile.Result, error) {
 	processLocalDatasetLogger := log.WithValues("Dataset.Namespace", cr.Namespace, "Dataset.Name", cr.Name, "Method", "processLocalDataset")
 
-	accessKeyID := cr.Spec.Local["accessKeyID"]
-	secretAccessKey := cr.Spec.Local["secretAccessKey"]
+	authProvided := false
+
+	var secretName, secretNamespace, accessKeyID, secretAccessKey string
+	var ok bool = false
+	if secretName, ok = cr.Spec.Local["secret-name"]; ok {
+		if secretNamespace, ok = cr.Spec.Local["secret-namespace"]; !ok {
+			processLocalDatasetLogger.Info("Warning: Secret namespace not provided, using the dataset namespace", "Dataset.Name", cr.Name)
+			secretNamespace = cr.Namespace
+		}
+
+		// Check if the secret is present
+		cosSecret := &corev1.Secret{}
+		err := rc.client.Get(context.TODO(), types.NamespacedName{Name: secretName, Namespace: secretNamespace}, cosSecret)
+
+		if err != nil && errors.IsNotFound(err) {
+			processLocalDatasetLogger.Error(err, "Provided secret not found! ", "Dataset.Name", cr.Name)
+		} else {
+			accessKeyID = cosSecret.StringData["accessKeyID"]
+			secretAccessKey = cosSecret.StringData["secretAccessKey"]
+		}
+		authProvided = true
+
+	} else {
+		if accessKeyID, ok = cr.Spec.Local["accessKeyID"]; ok {
+			if secretAccessKey, ok = cr.Spec.Local["secretAccessKey"]; !ok {
+				processLocalDatasetLogger.Error(nil, "Secret Key not provided with the access key", "Dataset.Name", cr.Name)
+				authProvided = false
+			} else {
+				authProvided = true
+			}
+		}
+	}
+
+	if !authProvided {
+		err := errors.New("No useable secret provided for authentication")
+		processLocalDatasetLogger.Error(err, "Failed to initialise", "Dataset.Name", cr.Name)
+		return reconcile.Result{}, err
+	}
+
 	endpoint := cr.Spec.Local["endpoint"]
 	bucket := cr.Spec.Local["bucket"]
 	region := cr.Spec.Local["region"]
 	readonly := "false"
+
 	if readonlyValueString, ok := cr.Spec.Local["readonly"]; ok {
 		readonly = readonlyValueString
 	}
+
 	extract := "false"
-	if(len(cr.Spec.Extract)>0) {
+	if len(cr.Spec.Extract) > 0 {
 		extract = cr.Spec.Extract
 	}
 


### PR DESCRIPTION
 Adding functionality to supply auth info for S3/COS datasets using secrets

Instead of:
` accessKeyID: "{AWS_ACCESS_KEY_ID}"`
` secretAccessKey: "{AWS_SECRET_ACCESS_KEY}"`


the user can provide:
`secret-name: "{SECRET_NAME}"`
`secret-namespace: "{SECRET_NAMESPACE}"` 


secret-namespace is optional if the secret is defined in the same namespace as the dataset